### PR TITLE
Get-UEFIVariable -All will never return the final UEFI variable

### DIFF
--- a/UEFIv2.psm1
+++ b/UEFIv2.psm1
@@ -1010,4 +1010,4 @@ PROCESS {
 END { Write-Verbose "Function ${CmdletName} finished." }
 
 } # end Function Set-LHSTokenPrivilege                
- 
+ 

--- a/UEFIv2.psm1
+++ b/UEFIv2.psm1
@@ -110,29 +110,34 @@ function Get-UEFIVariable
     PROCESS {
         if ($All) {
             # Get the full variable list
-            $VARIABLE_INFORMATION_NAMES = 1
-            $size = 1024 * 1024
+            $ENUM_TYPE_VARIABLE_NAME = 1
+            $size = 0
+            $rc = $uefiNative[0]::NtEnumerateSystemEnvironmentValuesEx($ENUM_TYPE_VARIABLE_NAME, $null, [ref] $size)
             $result = New-Object Byte[]($size)
-            $rc = $uefiNative[0]::NtEnumerateSystemEnvironmentValuesEx($VARIABLE_INFORMATION_NAMES, $result, [ref] $size)
+
+            $rc = $uefiNative[0]::NtEnumerateSystemEnvironmentValuesEx($ENUM_TYPE_VARIABLE_NAME, $result, [ref] $size)
             $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
             if ($rc -eq 0)
             {
                 $currentPos = 0
-                while ($true)
+                do
                 {
                     # Get the offset to the next entry
                     $nextOffset = [System.BitConverter]::ToUInt32($result, $currentPos)
-                    if ($nextOffset -eq 0)
-                    {
-                        break
-                    }
     
                     # Get the vendor GUID for the current entry
                     $guidBytes = $result[($currentPos + 4)..($currentPos + 4 + 15)]
                     [Guid] $vendor = [Byte[]]$guidBytes
                     
                     # Get the name of the current entry
-                    $name = [System.Text.Encoding]::Unicode.GetString($result[($currentPos + 20)..($currentPos + $nextOffset - 1)])
+                    if ($nextOffset -gt 0)
+                    {
+                        $name = [System.Text.Encoding]::Unicode.GetString($result[($currentPos + 20)..($currentPos + $nextOffset - 1)])
+                    }
+                    else
+                    {
+                        $name = [System.Text.Encoding]::Unicode.GetString($result[($currentPos + 20)..($size - 1)])
+                    }
     
                     # Return a new object to the pipeline
                     New-Object PSObject -Property @{Namespace = $vendor.ToString('B'); VariableName = $name.Replace("`0","") }
@@ -140,6 +145,7 @@ function Get-UEFIVariable
                     # Advance to the next entry
                     $currentPos = $currentPos + $nextOffset
                 }
+                until ($nextOffset -eq 0)
             }
             else
             {
@@ -180,7 +186,6 @@ function Get-UEFIVariable
                 }
             }
         }
-
     }
     END {
         $rc = Set-LHSTokenPrivilege -Privilege SeSystemEnvironmentPrivilege -Disable
@@ -1005,4 +1010,4 @@ PROCESS {
 END { Write-Verbose "Function ${CmdletName} finished." }
 
 } # end Function Set-LHSTokenPrivilege                
- 
+ 


### PR DESCRIPTION
1.  **Get-UEFIVariable -All** will never return the final UEFI variable, because the while-loop exited prematurely.  When _($nextOffset -eq 0)_, there's one more variable left for processing.  Switching to a do-until loop fixes the issue.

2.  Use dynamic memory allocation instead of a static array size for _$results_.  Calling NtEnumerateSystemEnvironmentValuesEx() with a null buffer will return the data structure's actual byte size.  This can be used to correctly assign the byte size for **New-Object Byte[]**.